### PR TITLE
mildly broke FORCERENEW spec to support htiachi expected operation

### DIFF
--- a/client/dhclient.c
+++ b/client/dhclient.c
@@ -2377,8 +2377,12 @@ void dhcpforcerenew_request (client)
 		log_error ("forcerenew: no client provided");
 		return;
 	}
-	if (client->state != S_BOUND) {
-		log_info ("forcerenew: client not in BOUND state");
+	/*due to bug https://github.com/razorsecure/delta/issues/8065 we intentionally break the force renew spec to
+	allow any states with active leases. An active lease is required because later on we construct a new request
+	based off said active lease, and i dont know enough of dhclient to start a new retest from scratch
+	*/
+	if (!((client->state == S_REQUESTING) || (client->state == S_BOUND) || (client->state == S_RENEWING))) {
+		log_info ("forcerenew: client not in an active state");
 		return;
 	}
 	log_info ("forcerenew: entering the RENEWING state");

--- a/client/dhclient.c
+++ b/client/dhclient.c
@@ -83,8 +83,8 @@ static const char message [] = "Internet Systems Consortium DHCP Client";
 static const char url [] = "For info, please visit https://www.isc.org/software/dhcp/";
 #endif /* UNIT_TEST */
 
-u_int16_t local_port = 0;
-u_int16_t remote_port = 0;
+extern u_int16_t local_port;
+extern u_int16_t remote_port;
 #if defined(DHCPv6) && defined(DHCP4o6)
 int dhcp4o6_state = -1; /* -1 = stopped, 0 = polling, 1 = started */
 #endif

--- a/common/discover.c
+++ b/common/discover.c
@@ -42,8 +42,8 @@
 struct interface_info *interfaces, *dummy_interfaces, *fallback_interface;
 int interfaces_invalidated;
 int quiet_interface_discovery;
-u_int16_t local_port;
-u_int16_t remote_port;
+u_int16_t local_port = 0;
+u_int16_t remote_port = 0;
 u_int16_t relay_port = 0;
 int dhcpv4_over_dhcpv6 = 0;
 int (*dhcp_interface_setup_hook) (struct interface_info *, struct iaddr *);

--- a/relay/dhcrelay.c
+++ b/relay/dhcrelay.c
@@ -95,8 +95,8 @@ enum { forward_and_append,	/* Forward and append our own relay option. */
        forward_untouched,	/* Forward without changes. */
        discard } agent_relay_mode = forward_and_replace;
 
-u_int16_t local_port;
-u_int16_t remote_port;
+extern u_int16_t local_port;
+extern u_int16_t remote_port;
 
 /* Relay agent server list. */
 struct server_list {

--- a/server/mdb.c
+++ b/server/mdb.c
@@ -67,7 +67,7 @@ static host_id_info_t *host_id_info = NULL;
 
 int numclasseswritten;
 
-omapi_object_type_t *dhcp_type_host;
+extern omapi_object_type_t *dhcp_type_host;
 
 isc_result_t enter_class(cd, dynamicp, commit)
 	struct class *cd;

--- a/server/mdb6.c
+++ b/server/mdb6.c
@@ -1945,7 +1945,7 @@ create_prefix6(struct ipv6_pool *pool, struct iasubopt **pref,
 		}
 		new_ds.data = new_ds.buffer->data;
 		memcpy(new_ds.buffer->data, ds.data, ds.len);
-		memcpy(new_ds.buffer->data + ds.len, &tmp, sizeof(tmp));
+		memcpy(&new_ds.buffer->data[0] + ds.len, &tmp, sizeof(tmp));
 		data_string_forget(&ds, MDL);
 		data_string_copy(&ds, &new_ds, MDL);
 		data_string_forget(&new_ds, MDL);


### PR DESCRIPTION
closes razorsecure/delta#8065

changes:
- adds a commit from upstream to fix building with GCC10+
- allows FORCERENEW from any active state

evidence (top left, tcpdump from server pov, top right tcpreplay of FORCE RENEW command, bottom dhclient logs):

old dhclient:

![image](https://github.com/razorsecure/dhcp/assets/46323623/0ba86274-b0fc-457a-8cc1-573b1e136a4c)

new dhclient:

![image](https://github.com/razorsecure/dhcp/assets/46323623/9fffbc39-0f02-44da-845d-c89920319145)
